### PR TITLE
Convert non-word chars to '_' for struct field names

### DIFF
--- a/lib/data_morph/struct.ex
+++ b/lib/data_morph/struct.ex
@@ -82,10 +82,9 @@ defmodule DataMorph.Struct do
 
   defp extract_fields stream do
     stream
-    |> Enum.take(1)
-    |> List.first
+    |> Enum.at(0)
     |> Map.keys
-    |> Enum.map(&(String.to_atom &1))
+    |> Enum.map(&String.to_atom/1)
   end
 
 end

--- a/lib/data_morph/struct.ex
+++ b/lib/data_morph/struct.ex
@@ -55,36 +55,52 @@ defmodule DataMorph.Struct do
   Defines a struct and returns stream of structs created from stream of maps.
 
       iex> [
-      iex>   %{"name" => "New Zealand", "iso" => "nz"},
-      iex>   %{"name" => "United Kingdom", "iso" => "gb"}
+      iex>   %{"name" => "New Zealand", "ISO code" => "nz"},
+      iex>   %{"name" => "United Kingdom", "ISO code" => "gb"}
       iex> ]
       iex> |> Stream.map &(&1)
       iex> |> DataMorph.Struct.from_maps(OpenRegister, "country")
-      [%OpenRegister.Country{iso: "nz", name: "New Zealand"},
-      %OpenRegister.Country{iso: "gb", name: "United Kingdom"}]
+      [%OpenRegister.Country{iso_code: "nz", name: "New Zealand"},
+      %OpenRegister.Country{iso_code: "gb", name: "United Kingdom"}]
 
   Defines a struct and returns stream of structs created from list of maps.
 
       iex> DataMorph.Struct.from_maps OpenRegister, "country", [
-      iex>   %{"name" => "New Zealand", "iso" => "nz"},
-      iex>   %{"name" => "United Kingdom", "iso" => "gb"}
+      iex>   %{"name" => "New Zealand", "ISO code" => "nz"},
+      iex>   %{"name" => "United Kingdom", "ISO code" => "gb"}
       iex> ]
-      [%OpenRegister.Country{iso: "nz", name: "New Zealand"},
-      %OpenRegister.Country{iso: "gb", name: "United Kingdom"}]
+      [%OpenRegister.Country{iso_code: "nz", name: "New Zealand"},
+      %OpenRegister.Country{iso_code: "gb", name: "United Kingdom"}]
 
   """
   def from_maps stream, namespace, name do
     kind = DataMorph.Module.camelize_concat(namespace, name)
-    fields = extract_fields(stream)
-    defmodulestruct kind, fields
-    ParallelStream.map stream, &(Maptu.struct!(kind, &1))
+    fields = stream |> extract_fields
+    defmodulestruct kind, Map.values(fields)
+    stream
+    |> ParallelStream.map(&(&1 |> convert_keys(fields)))
+    |> ParallelStream.map(&(struct(kind, &1)))
+  end
+
+  defp convert_keys map, fields do
+    for {key, val} <- map, into: %{}, do: {fields[key], val}
+  end
+
+  defp normalize string do
+    string
+    |> String.downcase
+    |> String.replace(~r"\W", " ")
+    |> String.replace(~r"  +", " ")
+    |> String.strip()
+    |> String.replace(" ", "_")
+    |> String.to_atom
   end
 
   defp extract_fields stream do
     stream
     |> Enum.at(0)
     |> Map.keys
-    |> Enum.map(&String.to_atom/1)
+    |> Map.new(fn x -> {x, normalize(x)} end)
   end
 
 end

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,6 @@ defmodule DataMorph.Mixfile do
   defp deps do
     [
       {:csv, "~> 1.4.0"},
-      {:maptu, ">= 0.0.0"},
       {:mix_test_watch, "~> 0.2", only: :dev},
       {:parallel_stream, "~> 1.0.3"},
     ]

--- a/test/data_morph_test.exs
+++ b/test/data_morph_test.exs
@@ -5,14 +5,14 @@ defmodule DataMorphTest do
   doctest DataMorph.Module
 
   setup do
-    stream = "name\tiso\nNew Zealand\tnz\nUnited Kingdom\tgb"
+    stream = "name\tISO code\nNew Zealand\tnz\nUnited Kingdom\tgb"
              |> String.split("\n")
              |> Stream.map(&(&1))
     {:ok, [tsv: stream]}
   end
 
   def assert_struct item, expected_kind, expected_iso, expected_name do
-    [__struct__: kind, iso: iso, name: name] = Map.to_list item
+    [__struct__: kind, iso_code: iso, name: name] = Map.to_list item
     assert Atom.to_string(kind) == "Elixir.#{expected_kind}"
     assert iso == expected_iso
     assert name == expected_name
@@ -32,8 +32,8 @@ defmodule DataMorphTest do
 
   test "from_maps/3 defines struct and returns stream of maps converted to structs" do
     structs = [
-                %{"name" => "New Zealand", "iso" => "nz"},
-                %{"name" => "United Kingdom", "iso" => "gb"}
+                %{"name" => "New Zealand", "ISO code" => "nz"},
+                %{"name" => "United Kingdom", "ISO code" => "gb"}
               ]
               |> DataMorph.Struct.from_maps(OpenRegister, "country")
 


### PR DESCRIPTION
When header text contains non-word characters or spaces, convert them to '_'. Strip whitespace and squeeze whitespace.

Remove usage of Maptu to create structs. Instead convert keys to atoms in map passed to create a struct.
