### PR TITLE
Ensure macro called second time with same fields doesn't redefine struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.0.2 (2016-08-07)
+
+* Bug Fixes
+  * When `defmodulestruct/2` macro called a second time with the same fields don't redefine struct
+
+## 0.0.1 (2016-08-01)
+
+* Initial release

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ You can view [full DataMorph API documentation on hexdocs](https://hexdocs.pm/da
 
 Add
 ```elixir
-{:data_morph, "~> 0.0.1"}
+{:data_morph, "~> 0.0.2"}
 ```
 to your deps in `mix.exs` like so:
 
 ```elixir
 defp deps do
   [
-    {:data_morph, "~> 0.0.1"}
+    {:data_morph, "~> 0.0.2"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Create Elixir structs from data.
 
 [![Build Status](https://api.travis-ci.org/robmckinnon/data_morph.svg)](https://travis-ci.org/robmckinnon/data_morph)
 [![Inline docs](http://inch-ci.org/github/robmckinnon/data_morph.svg)](http://inch-ci.org/github/robmckinnon/data_morph)
+[![Hex.pm](https://img.shields.io/hexpm/v/data_morph.svg)](https://hex.pm/packages/data_morph)
 
 ## Documentation
 

--- a/lib/data_morph/struct.ex
+++ b/lib/data_morph/struct.ex
@@ -24,31 +24,27 @@ defmodule DataMorph.Struct do
   """
   defmacro defmodulestruct kind, fields do
     quote do
-      value = try do
-        template = struct unquote(kind)
+      module = unquote(kind)
+      fields = unquote(fields)
+      try do
+        template = struct module
         existing_fields = template
                           |> Map.to_list
                           |> Keyword.keys
                           |> MapSet.new
                           |> MapSet.delete(:__struct__)
-
-        new_fields = MapSet.new unquote(fields)
+        new_fields = MapSet.new fields
 
         if MapSet.equal? existing_fields, new_fields do
-          {:module, unquote(kind), nil, template}
+          {:module, module, nil, template}
         else
-          union = MapSet.union(existing_fields, new_fields)
-          defmodule Module.concat([ unquote(kind) ]) do
-            defstruct MapSet.to_list(union)
-          end
+          fields_union = MapSet.union(existing_fields, new_fields) |> MapSet.to_list
+          defmodule Module.concat([ module ]), do: defstruct fields_union
         end
       rescue
         UndefinedFunctionError ->
-          defmodule Module.concat([ unquote(kind) ]) do
-            defstruct unquote(fields)
-          end
+          defmodule Module.concat([ module ]), do: defstruct fields
       end
-      value
     end
   end
 

--- a/lib/data_morph/struct.ex
+++ b/lib/data_morph/struct.ex
@@ -26,7 +26,12 @@ defmodule DataMorph.Struct do
     quote do
       value = try do
         template = struct unquote(kind)
-        existing_fields = template |> Map.to_list |> Keyword.keys |> MapSet.new
+        existing_fields = template
+                          |> Map.to_list
+                          |> Keyword.keys
+                          |> MapSet.new
+                          |> MapSet.delete(:__struct__)
+
         new_fields = MapSet.new unquote(fields)
 
         if MapSet.equal? existing_fields, new_fields do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule DataMorph.Mixfile do
   use Mix.Project
 
-  @version "0.0.1"
+  @version "0.0.2"
 
   def project do
     [app: :data_morph,

--- a/test/data_morph/struct_test.exs
+++ b/test/data_morph/struct_test.exs
@@ -9,8 +9,17 @@ defmodule DataMorphStructTest do
   end
 
   test "defmodulestruct/2 macro defines struct with correct template" do
-    {:module, _, _, template} = DataMorph.Struct.defmodulestruct(Bar.Foo, [:baz, :boom])
+    {:module, _, binary, template} = DataMorph.Struct.defmodulestruct(Bar.Foo, [:baz, :boom])
     assert Map.to_list(template) == [__struct__: Bar.Foo, baz: nil, boom: nil]
+    assert is_binary(binary)
+  end
+
+  test "defmodulestruct/2 macro called second time with same field keys doesn't redefine struct" do
+    DataMorph.Struct.defmodulestruct(Foo.Bar.Foo, [:baz, :boom])
+
+    {:module, _, binary, template} = DataMorph.Struct.defmodulestruct(Foo.Bar.Foo, [:baz, :boom])
+    assert Map.to_list(template) == [__struct__: Foo.Bar.Foo, baz: nil, boom: nil]
+    assert binary == nil
   end
 
   test "defmodulestruct/2 macro called second time with additional new field redefines struct" do
@@ -20,9 +29,9 @@ defmodule DataMorphStructTest do
   end
 
   test "defmodulestruct/2 macro called second time without original fields redefines struct leaving original keys in struct" do
-    DataMorph.Struct.defmodulestruct(Baz.Foo, [:baz, :boom])
-    {:module, _, _, template} = DataMorph.Struct.defmodulestruct(Baz.Foo, [:bish])
-    assert Map.to_list(template) == [__struct__: Baz.Foo, baz: nil, bish: nil, boom: nil]
+    DataMorph.Struct.defmodulestruct(Foo.Baz.Foo, [:baz, :boom])
+    {:module, _, _, template} = DataMorph.Struct.defmodulestruct(Foo.Baz.Foo, [:bish])
+    assert Map.to_list(template) == [__struct__: Foo.Baz.Foo, baz: nil, bish: nil, boom: nil]
   end
 
   test "redefining struct definition only adds keys to new structs" do


### PR DESCRIPTION
- When `defmodulestruct/2` macro called a second time with the same fields don't redefine struct.
- Bump version to 0.0.2.
