### PR TITLE
Don't redefine struct when given same fields in different order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.0.3 (2016-08-14)
+
+* Bug Fixes
+  * When `defmodulestruct/2` macro called a second time with the same fields in different order don't redefine struct
+
 ## 0.0.2 (2016-08-07)
 
 * Bug Fixes

--- a/lib/data_morph/struct.ex
+++ b/lib/data_morph/struct.ex
@@ -28,9 +28,11 @@ defmodule DataMorph.Struct do
       fields = unquote(fields)
       fields_changeset = try do
                            existing_fields = (struct(module) |> Map.keys) -- [:__struct__]
-                           unless existing_fields === fields do
-                             MapSet.new(existing_fields)
-                             |> MapSet.union(MapSet.new(fields))
+                           existing_fieldset = MapSet.new(existing_fields)
+                           new_fieldset = MapSet.new(fields)
+                           unless existing_fieldset === new_fieldset do
+                             existing_fieldset
+                             |> MapSet.union(new_fieldset)
                              |> MapSet.to_list
                            end
                          rescue

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule DataMorph.Mixfile do
   use Mix.Project
 
-  @version "0.0.2"
+  @version "0.0.3"
 
   def project do
     [app: :data_morph,

--- a/test/data_morph/struct_test.exs
+++ b/test/data_morph/struct_test.exs
@@ -22,6 +22,14 @@ defmodule DataMorphStructTest do
     assert binary == nil
   end
 
+  test "defmodulestruct/2 macro called second time with same field keys in different order doesn't redefine struct" do
+    DataMorph.Struct.defmodulestruct(Foo.Bar.Foo.Bar, [:baz, :boom])
+
+    {:module, _, binary, template} = DataMorph.Struct.defmodulestruct(Foo.Bar.Foo.Bar, [:boom, :baz])
+    assert Map.to_list(template) == [__struct__: Foo.Bar.Foo.Bar, baz: nil, boom: nil]
+    assert binary == nil
+  end
+
   test "defmodulestruct/2 macro called second time with additional new field redefines struct" do
     DataMorph.Struct.defmodulestruct(Baz.Foo, [:baz, :boom])
     {:module, _, _, template} = DataMorph.Struct.defmodulestruct(Baz.Foo, [:baz, :boom, :bish])


### PR DESCRIPTION
When macro called a second time with the same fields in different order don't redefine struct.

Bump version to 0.0.3.
