### PR TITLE
Fix processing IO.stream to structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.0.4 (2016-09-09)
+
+* Bug Fixes
+  * Change code to only process line at first position of stream once, to fix bug processing from IO.stream :stdio
+
 ## 0.0.3 (2016-08-14)
 
 * Bug Fixes

--- a/README.md
+++ b/README.md
@@ -42,20 +42,32 @@ iex> "name\tiso\n" <>
 ]
 ```
 
-Define a struct and return stream of structs created from a `tsv` stream, and a `namespace` string and `name` atom.
+Define a struct and return stream of structs created from a `csv` file stream,
+and a `namespace` string and `name` atom.
+
+```sh
+(echo name,iso && echo New Zealand,nz && echo United Kingdom,gb) > tmp.csv
+```
 
 ```elixir
-iex> "name\tiso\n" <>
-...> "New Zealand\tnz\n" <>
-...> "United Kingdom\tgb" \
-...> |> String.split("\n") \
-...> |> Stream.map(& &1) \
-...> |> DataMorph.structs_from_tsv("open-register", :iso_country) \
+iex> File.stream!('./tmp.csv') \
+...> |> DataMorph.structs_from_csv("open-register", :iso_country) \
 ...> |> Enum.to_list
 [
   %OpenRegister.IsoCountry{iso: "nz", name: "New Zealand"},
   %OpenRegister.IsoCountry{iso: "gb", name: "United Kingdom"}
 ]
+```
+
+Define a struct and puts stream of structs created from a stream of `csv`
+on standard input, and a `namespace` atom, and `name` string.
+```sh
+(echo name,iso && echo New Zealand,NZ) | \
+    mix run -e 'IO.puts inspect \
+    IO.stream(:stdio, :line) \
+    |> DataMorph.structs_from_csv(:ex, "ample") \
+    |> Enum.at(0)'
+# %Ex.Ample{iso: "NZ", name: "New Zealand"}
 ```
 
 Add additional new fields to struct when called again with different `tsv`.

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ You can view [full DataMorph API documentation on hexdocs](https://hexdocs.pm/da
 
 Add
 ```elixir
-{:data_morph, "~> 0.0.3"}
+{:data_morph, "~> 0.0.4"}
 ```
 to your deps in `mix.exs` like so:
 
 ```elixir
 defp deps do
   [
-    {:data_morph, "~> 0.0.3"}
+    {:data_morph, "~> 0.0.4"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule DataMorph.Mixfile do
   use Mix.Project
 
-  @version "0.0.3"
+  @version "0.0.4"
 
   def project do
     [app: :data_morph,

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"csv": {:hex, :csv, "1.4.2", "cedb2f230171e6d10423aee8ce90512833b07e978747cc836b0f2c037fcf779d", [:mix], [{:parallel_stream, "~> 1.0.4", [hex: :parallel_stream, optional: false]}]},
+%{"csv": {:hex, :csv, "1.4.3", "de92e2bc85bc09ec676f19f6ec2daa59ba1f0103d1da96cf0cca36342c90d93f", [:mix], [{:parallel_stream, "~> 1.0.4", [hex: :parallel_stream, optional: false]}]},
   "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},

--- a/test/data_morph/struct_test.exs
+++ b/test/data_morph/struct_test.exs
@@ -1,5 +1,6 @@
 defmodule DataMorphStructTest do
   use ExUnit.Case, async: true
+  import ExUnit.CaptureIO
 
   require DataMorph.Struct
 
@@ -32,14 +33,20 @@ defmodule DataMorphStructTest do
 
   test "defmodulestruct/2 macro called second time with additional new field redefines struct" do
     DataMorph.Struct.defmodulestruct(Baz.Foo, [:baz, :boom])
-    {:module, _, _, template} = DataMorph.Struct.defmodulestruct(Baz.Foo, [:baz, :boom, :bish])
-    assert Map.to_list(template) == [__struct__: Baz.Foo, baz: nil, bish: nil, boom: nil]
+    warning = capture_io(:stderr, fn ->
+      {:module, _, _, template} = DataMorph.Struct.defmodulestruct(Baz.Foo, [:baz, :boom, :bish])
+      assert Map.to_list(template) == [__struct__: Baz.Foo, baz: nil, bish: nil, boom: nil]
+    end)
+    assert warning |> String.contains?("redefining module Baz.Foo")
   end
 
   test "defmodulestruct/2 macro called second time without original fields redefines struct leaving original keys in struct" do
     DataMorph.Struct.defmodulestruct(Foo.Baz.Foo, [:baz, :boom])
-    {:module, _, _, template} = DataMorph.Struct.defmodulestruct(Foo.Baz.Foo, [:bish])
-    assert Map.to_list(template) == [__struct__: Foo.Baz.Foo, baz: nil, bish: nil, boom: nil]
+    warning = capture_io(:stderr, fn ->
+      {:module, _, _, template} = DataMorph.Struct.defmodulestruct(Foo.Baz.Foo, [:bish])
+      assert Map.to_list(template) == [__struct__: Foo.Baz.Foo, baz: nil, bish: nil, boom: nil]
+    end)
+    assert warning |> String.contains?("redefining module Foo.Baz.Foo")
   end
 
   test "redefining struct definition only adds keys to new structs" do
@@ -48,7 +55,10 @@ defmodule DataMorphStructTest do
     assert Map.has_key? original, :original_attribute
     assert !Map.has_key? original, :new_attribute
 
-    Code.eval_string("defmodule Example, do: defstruct [:original_attribute, :new_attribute]")
+    warning = capture_io(:stderr, fn ->
+      Code.eval_string("defmodule Example, do: defstruct [:original_attribute, :new_attribute]")
+    end)
+    assert warning |> String.contains?("redefining module Example")
     { updated, _ } = Code.eval_string("%Example{ new_attribute: 'bye' }")
     assert Map.has_key? updated, :original_attribute
     assert Map.has_key? updated, :new_attribute

--- a/test/data_morph_test.exs
+++ b/test/data_morph_test.exs
@@ -42,4 +42,17 @@ defmodule DataMorphTest do
     assert_structs "OpenRegister.Country", structs
   end
 
+  test "structs_from_csv/2 returns correct result from IO.stream of :stdio" do
+    result = "
+    (echo name,iso && echo New Zealand,NZ) | \
+    mix run -e 'IO.write inspect \
+    IO.stream(:stdio, :line) \
+    |> DataMorph.structs_from_csv(:ex, :ample) \
+    |> Enum.at(0)'"
+    |> String.to_char_list
+    |> :os.cmd
+
+    assert String.contains? "#{result}", "#{'%Ex.Ample{iso: "NZ", name: "New Zealand"}'}"
+  end
+
 end


### PR DESCRIPTION
- Change code to only process line at first position of stream once, to fix bug processing from IO.stream.
- Capture redefining module warnings in tests.
- Add file stream and IO stream examples to readme.
