### PR TITLE
Add `keyword_lists_from_tsv/1` and `keyword_lists_from_csv/2` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 0.0.6
 
 * Features
-  * Add `keyword_lists_from_tsv/1` that returns keyword lists stream for given TSV
+  * Add `keyword_lists_from_tsv/1` and `keyword_lists_from_csv/2` that returns keyword lists stream for given TSV/CSV
+  * Add `maps_from_tsv/1` and `maps_from_csv/2` that returns maps with atom keys stream for given TSV/CSV
   * Add `filter_and_take/3` that returns stream with filter regexp and take count applied
   * Add `puts_tsv/1` and `puts_tsv/2` functions to write streams of string lists as TSV to stdout
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.0.6
 
 * Features
+  * Add `keyword_lists_from_tsv/1` that returns keyword lists stream for given TSV
   * Add `filter_and_take/3` that returns stream with filter regexp and take count applied
   * Add `puts_tsv/1` and `puts_tsv/2` functions to write streams of string lists as TSV to stdout
 

--- a/lib/data_morph.ex
+++ b/lib/data_morph.ex
@@ -1,8 +1,8 @@
 defmodule DataMorph do
   @moduledoc ~S"""
-  Create Elixir structs from data.
+  Create Elixir structs, maps with atom keys, and keyword lists from CSV/TSV data.
 
-  ## Example
+  ## Examples
 
   Define a struct and return stream of structs created from a `tsv` string, a
   `namespace` atom and `name` string.
@@ -17,6 +17,31 @@ defmodule DataMorph do
         %OpenRegister.Country{iso: "gb", name: "United Kingdom"}
       ]
 
+  Return stream of maps with atom keys created from a `tsv` stream.
+
+      iex> "name\tiso-code\n" <>
+      ...> "New Zealand\tnz\n" <>
+      ...> "United Kingdom\tgb" \
+      ...> |> String.split("\n") \
+      ...> |> Stream.map(& &1) \
+      ...> |> DataMorph.maps_from_tsv() \
+      ...> |> Enum.to_list
+      [
+        %{iso_code: "nz", name: "New Zealand"},
+        %{iso_code: "gb", name: "United Kingdom"}
+      ]
+
+  Return stream of keyword lists created from a `tsv` string.
+
+      iex> "name\tiso-code\n" <>
+      ...> "New Zealand\tnz\n" <>
+      ...> "United Kingdom\tgb" \
+      ...> |> DataMorph.keyword_lists_from_tsv() \
+      ...> |> Enum.to_list
+      [
+        [name: "New Zealand", "iso-code": "nz"],
+        [name: "United Kingdom", "iso-code": "gb"]
+      ]
   """
 
   require DataMorph.Struct

--- a/lib/data_morph.ex
+++ b/lib/data_morph.ex
@@ -87,6 +87,7 @@ defmodule DataMorph do
    - `csv`: CSV stream or string
    - `namespace`: string or atom to form first part of struct alias
    - `name`: string or atom to form last part of struct alias
+   - `options`: optionally pass in separator, e.g. separator: ";"
   """
   def structs_from_csv(csv, namespace, name, options \\ [separator: ","]) do
     {headers, rows} = csv
@@ -118,7 +119,6 @@ defmodule DataMorph do
   ## Parmeters
 
    - `tsv`: TSV stream or string
-
   """
   def maps_from_tsv tsv do
     tsv |> maps_from_csv(separator: ?\t)
@@ -130,7 +130,7 @@ defmodule DataMorph do
   ## Parmeters
 
    - `csv`: CSV stream or string
-
+   - `options`: optionally pass in separator, e.g. separator: ";"
   """
   def maps_from_csv(csv, options \\ [separator: ","]) do
     {headers, rows} = csv

--- a/lib/data_morph.ex
+++ b/lib/data_morph.ex
@@ -162,8 +162,21 @@ defmodule DataMorph do
       ]
   """
   def keyword_lists_from_tsv tsv do
-    {headers, rows} = tsv
-      |> DataMorph.Csv.to_headers_and_rows_stream(separator: ?\t)
+    tsv |> keyword_lists_from_csv(separator: ?\t)
+  end
+
+  @doc ~S"""
+  Returns stream of keyword_lists created from `csv` string or stream.
+
+  Useful when you want to retain the field order of the original stream.
+
+  ## Parmeters
+   - `csv`: CSV stream or string
+   - `options`: optionally pass in separator, e.g. separator: ";"
+  """
+  def keyword_lists_from_csv(csv, options \\ [separator: ","]) do
+    {headers, rows} = csv
+      |> DataMorph.Csv.to_headers_and_rows_stream(options)
     keywords = headers |> Enum.map(& String.to_atom/1)
     rows
     |> Enum.map(& keywords |> Enum.zip(&1) )

--- a/lib/data_morph.ex
+++ b/lib/data_morph.ex
@@ -143,6 +143,33 @@ defmodule DataMorph do
   end
 
   @doc ~S"""
+  Returns stream of keyword_lists created from `tsv` string or stream.
+
+  Useful when you want to retain the field order of the original stream.
+
+  ## Example
+
+  Return stream of keyword lists created from a `tsv` string.
+
+      iex> "name\tiso-code\n" <>
+      ...> "New Zealand\tnz\n" <>
+      ...> "United Kingdom\tgb" \
+      ...> |> DataMorph.keyword_lists_from_tsv() \
+      ...> |> Enum.to_list
+      [
+        [name: "New Zealand", "iso-code": "nz"],
+        [name: "United Kingdom", "iso-code": "gb"]
+      ]
+  """
+  def keyword_lists_from_tsv tsv do
+    {headers, rows} = tsv
+      |> DataMorph.Csv.to_headers_and_rows_stream(separator: ?\t)
+    keywords = headers |> Enum.map(& String.to_atom/1)
+    rows
+    |> Enum.map(& keywords |> Enum.zip(&1) )
+  end
+
+  @doc ~S"""
   Takes stream and applies filter `regexp` when not nil, and takes `count` when
   not nil.
 

--- a/test/data_morph_test.exs
+++ b/test/data_morph_test.exs
@@ -39,9 +39,21 @@ defmodule DataMorphTest do
     assert_maps maps
   end
 
+  def assert_keyword_lists stream do
+    list = stream |> Enum.to_list
+    assert Enum.count(list) == 2
+    assert (list |> List.first) == [{:"name", "New Zealand"}, {:"ISO code", "nz"}]
+    assert (list |> List.last) == [{:"name", "United Kingdom"}, {:"ISO code", "gb"}]
+  end
+
   test "creates structs from TSV", context do
     structs = DataMorph.structs_from_tsv(context[:tsv], OpenRegister, :iso_country)
     assert_structs "OpenRegister.IsoCountry", structs
+  end
+
+  test "creates keyword lists from TSV", context do
+    lists = DataMorph.keyword_lists_from_tsv(context[:tsv])
+    assert_keyword_lists lists
   end
 
   test "from_rows/3 defines struct and returns stream of rows converted to structs" do


### PR DESCRIPTION
Add functions to return stream of keyword lists created from a `tsv` or `csv` string or stream.