### PR TITLE
Add maps_from_csv/2 and maps_from_tsv/1 functions

### DIFF
--- a/lib/data_morph.ex
+++ b/lib/data_morph.ex
@@ -97,6 +97,52 @@ defmodule DataMorph do
   end
 
   @doc ~S"""
+  Returns stream of maps with atom keys created from `tsv` string or stream.
+
+  ## Example
+
+  Return stream of maps with atom keys created from a `tsv` stream.
+
+      iex> "name\tiso-code\n" <>
+      ...> "New Zealand\tnz\n" <>
+      ...> "United Kingdom\tgb" \
+      ...> |> String.split("\n") \
+      ...> |> Stream.map(& &1) \
+      ...> |> DataMorph.maps_from_tsv() \
+      ...> |> Enum.to_list
+      [
+        %{iso_code: "nz", name: "New Zealand"},
+        %{iso_code: "gb", name: "United Kingdom"}
+      ]
+
+  ## Parmeters
+
+   - `tsv`: TSV stream or string
+
+  """
+  def maps_from_tsv tsv do
+    tsv |> maps_from_csv(separator: ?\t)
+  end
+
+  @doc ~S"""
+  Returns stream of maps with atom keys created from `csv` string or stream.
+
+  ## Parmeters
+
+   - `csv`: CSV stream or string
+
+  """
+  def maps_from_csv(csv, options \\ [separator: ","]) do
+    {headers, rows} = csv
+      |> DataMorph.Csv.to_headers_and_rows_stream(options)
+
+    fields = headers |> Enum.map(&DataMorph.Struct.normalize/1)
+
+    rows
+    |> Stream.map(& fields |> Enum.zip(&1) |> Map.new)
+  end
+
+  @doc ~S"""
   Takes stream and applies filter `regexp` when not nil, and takes `count` when
   not nil.
 

--- a/lib/data_morph/struct.ex
+++ b/lib/data_morph/struct.ex
@@ -95,7 +95,7 @@ defmodule DataMorph.Struct do
     struct(kind, tuples)
   end
 
-  defp normalize string do
+  def normalize string do
     string
     |> String.downcase
     |> String.replace(~r"\W", " ")

--- a/test/data_morph_test.exs
+++ b/test/data_morph_test.exs
@@ -27,6 +27,18 @@ defmodule DataMorphTest do
     List.last(list)  |> assert_struct(kind, "gb", "United Kingdom")
   end
 
+  def assert_maps stream do
+    list = stream |> Enum.to_list
+    assert Enum.count(list) == 2
+    assert List.first(list) == %{iso_code: "nz", name: "New Zealand"}
+    assert List.last(list) == %{iso_code: "gb", name: "United Kingdom"}
+  end
+
+  test "creates maps with atom keys from TSV", context do
+    maps = DataMorph.maps_from_tsv(context[:tsv])
+    assert_maps maps
+  end
+
   test "creates structs from TSV", context do
     structs = DataMorph.structs_from_tsv(context[:tsv], OpenRegister, :iso_country)
     assert_structs "OpenRegister.IsoCountry", structs


### PR DESCRIPTION
Add functions to generate list of maps with atom keys from TSV or CSV stream or string.